### PR TITLE
[ ddaynew365 ]  요청 페이지 레이아웃 구현 및 더미 데이터 연동

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "chrome debugger",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}/src"
+    }
+  ]
+}

--- a/client/src/Page/Page.tsx
+++ b/client/src/Page/Page.tsx
@@ -5,6 +5,7 @@ import CowDogPage from "./CowDogPage";
 import LogInPage from "./LogInPage";
 import MyPage from "./MyPage";
 import RegisterPage from "./RegisterPage";
+import RequestPage from "./RequestPage";
 import TeamCreatePage from "./TeamCreatePage";
 import TeamSettingPage from "./TeamSettingPage";
 
@@ -19,6 +20,7 @@ function App() {
         <Route path="/sub/teamCreate" component={TeamCreatePage} />
         <Route path="/sub/teamSetting" component={TeamSettingPage} />
         <Route path="/sub/mypage" component={MyPage} />
+        <Route path="/sub/Request" component={RequestPage} />
       </Switch>
     </>
   );

--- a/client/src/Page/Page.tsx
+++ b/client/src/Page/Page.tsx
@@ -4,6 +4,7 @@ import Header from "../Organism/Header";
 import CowDogPage from "./CowDogPage";
 import LogInPage from "./LogInPage";
 import RegisterPage from "./RegisterPage";
+import RequestPage from "./RequestPage";
 import TeamCreatePage from "./TeamCreatePage";
 import TeamSettingPage from "./TeamSettingPage";
 
@@ -17,6 +18,7 @@ function App() {
         <Route path="/sub/CowDogPage" component={CowDogPage} />
         <Route path="/sub/teamCreate" component={TeamCreatePage} />
         <Route path="/sub/teamSetting" component={TeamSettingPage} />
+        <Route path="/sub/Request" component={RequestPage} />
       </Switch>
     </>
   );

--- a/client/src/Page/RequestPage.tsx
+++ b/client/src/Page/RequestPage.tsx
@@ -1,17 +1,18 @@
 /** @jsxImportSource @emotion/react */
 import React, { useEffect, useState } from "react";
 import { css } from "@emotion/react";
-import { useLocation } from "react-router-dom";
 import ProfileList from "../Template/ProfileList";
 import ProfileModal from "../Template/ProfileModal";
-import { getCowDogInfo } from "../util/dummyData";
-import { ProfileType } from "../util/type";
+import { getRequestInfo } from "../util/dummyData";
+import { ProfileType, RequestsType, RequestType } from "../util/type";
 
 export default function RequestPage() {
-  const [datas, setDatas] = useState<ProfileType[] | null>(null);
+  const [datas, setDatas] = useState<RequestsType | null>(null);
   const [openModal, setOpenModal] = useState<number | null>(null);
-  const searchParams = new URLSearchParams(useLocation().search);
-  const person = Number(searchParams.get("person"));
+  const myId = "123";
+  const person = 1;
+  const [RequestForMe, setRequestForMe] = useState<ProfileType[]>([]);
+  const [RequestToMe, setRequestToMe] = useState<ProfileType[]>([]);
 
   const RequestPageStyle = css`
     display: flex;
@@ -20,9 +21,20 @@ export default function RequestPage() {
     flex-direction: row;
     justify-content: center;
   `;
+  const RequestListStyle = css`
+    display: flex;
+    flex-direction: column;
+  `;
   const getDatas = async () => {
-    const item = await getCowDogInfo(person);
+    const item = await getRequestInfo();
     setDatas(item);
+    divideRequest();
+  };
+
+  const divideRequest = () => {
+    datas?.data.forEach((data: RequestType) => {
+      return data.from === myId ? setRequestForMe((prev) => [...prev, data.info]) : setRequestToMe((prev) => [...prev, data.info]);
+    });
   };
 
   useEffect(() => {
@@ -31,14 +43,17 @@ export default function RequestPage() {
   return (
     <>
       <div css={RequestPageStyle}>
-        <ProfileList datas={datas} person={person} setOpenModal={setOpenModal} />
-
-        {datas && openModal !== null && <ProfileModal data={datas[Number(openModal)]} />}
-        <ProfileList datas={datas} person={person} setOpenModal={setOpenModal} />
-
-        {datas && openModal !== null && <ProfileModal data={datas[Number(openModal)]} />}
+        <div css={RequestListStyle}>
+          <div>나에게 온 요청</div>
+          <ProfileList datas={RequestForMe} person={person} setOpenModal={setOpenModal} />
+          {datas && openModal !== null && <ProfileModal data={RequestForMe[Number(openModal)]} />}
+        </div>
+        <div css={RequestListStyle}>
+          <div>내가 보낸 요청</div>
+          <ProfileList datas={RequestToMe} person={person} setOpenModal={setOpenModal} />
+          {datas && openModal !== null && <ProfileModal data={RequestToMe[Number(openModal)]} />}
+        </div>
       </div>
-      <div>나에게 온 요청</div>
     </>
   );
 }

--- a/client/src/Page/RequestPage.tsx
+++ b/client/src/Page/RequestPage.tsx
@@ -1,0 +1,44 @@
+/** @jsxImportSource @emotion/react */
+import React, { useEffect, useState } from "react";
+import { css } from "@emotion/react";
+import { useLocation } from "react-router-dom";
+import ProfileList from "../Template/ProfileList";
+import ProfileModal from "../Template/ProfileModal";
+import { getCowDogInfo } from "../util/dummyData";
+import { ProfileType } from "../util/type";
+
+export default function RequestPage() {
+  const [datas, setDatas] = useState<ProfileType[] | null>(null);
+  const [openModal, setOpenModal] = useState<number | null>(null);
+  const searchParams = new URLSearchParams(useLocation().search);
+  const person = Number(searchParams.get("person"));
+
+  const RequestPageStyle = css`
+    display: flex;
+    width: 100vw;
+    height: 100vh;
+    flex-direction: row;
+    justify-content: center;
+  `;
+  const getDatas = async () => {
+    const item = await getCowDogInfo(person);
+    setDatas(item);
+  };
+
+  useEffect(() => {
+    getDatas();
+  }, []);
+  return (
+    <>
+      <div css={RequestPageStyle}>
+        <ProfileList datas={datas} person={person} setOpenModal={setOpenModal} />
+
+        {datas && openModal !== null && <ProfileModal data={datas[Number(openModal)]} />}
+        <ProfileList datas={datas} person={person} setOpenModal={setOpenModal} />
+
+        {datas && openModal !== null && <ProfileModal data={datas[Number(openModal)]} />}
+      </div>
+      <div>나에게 온 요청</div>
+    </>
+  );
+}

--- a/client/src/Page/RequestPage.tsx
+++ b/client/src/Page/RequestPage.tsx
@@ -4,15 +4,14 @@ import { css } from "@emotion/react";
 import ProfileList from "../Template/ProfileList";
 import ProfileModal from "../Template/ProfileModal";
 import { getRequestInfo } from "../util/dummyData";
-import { ProfileType, RequestsType, RequestType } from "../util/type";
+import { ProfileType, RequestType } from "../util/type";
 
 export default function RequestPage() {
-  const [datas, setDatas] = useState<RequestsType | null>(null);
+  const [RequestForMe, setRequestForMe] = useState<ProfileType[]>([]);
+  const [RequestToMe, setRequestToMe] = useState<ProfileType[]>([]);
   const [openModal, setOpenModal] = useState<number | null>(null);
   const myId = "123";
   const person = 1;
-  const [RequestForMe, setRequestForMe] = useState<ProfileType[]>([]);
-  const [RequestToMe, setRequestToMe] = useState<ProfileType[]>([]);
 
   const RequestPageStyle = css`
     display: flex;
@@ -25,14 +24,10 @@ export default function RequestPage() {
     display: flex;
     flex-direction: column;
   `;
+
   const getDatas = async () => {
     const item = await getRequestInfo();
-    setDatas(item);
-    divideRequest();
-  };
-
-  const divideRequest = () => {
-    datas?.data.forEach((data: RequestType) => {
+    item?.data.forEach((data: RequestType) => {
       return data.from === myId ? setRequestForMe((prev) => [...prev, data.info]) : setRequestToMe((prev) => [...prev, data.info]);
     });
   };
@@ -40,18 +35,19 @@ export default function RequestPage() {
   useEffect(() => {
     getDatas();
   }, []);
+
   return (
     <>
       <div css={RequestPageStyle}>
         <div css={RequestListStyle}>
           <div>나에게 온 요청</div>
           <ProfileList datas={RequestForMe} person={person} setOpenModal={setOpenModal} />
-          {datas && openModal !== null && <ProfileModal data={RequestForMe[Number(openModal)]} />}
+          {RequestForMe && openModal !== null && <ProfileModal data={RequestForMe[Number(openModal)]} />}
         </div>
         <div css={RequestListStyle}>
           <div>내가 보낸 요청</div>
           <ProfileList datas={RequestToMe} person={person} setOpenModal={setOpenModal} />
-          {datas && openModal !== null && <ProfileModal data={RequestToMe[Number(openModal)]} />}
+          {RequestToMe && openModal !== null && <ProfileModal data={RequestToMe[Number(openModal)]} />}
         </div>
       </div>
     </>

--- a/client/src/Page/RequestPage.tsx
+++ b/client/src/Page/RequestPage.tsx
@@ -14,13 +14,19 @@ export default function RequestPage() {
   const person = 1;
 
   const RequestPageStyle = css`
+    margin: 10vh 0 0 0;
     display: flex;
     width: 100vw;
     height: 100vh;
     flex-direction: row;
     justify-content: center;
   `;
+  const RequestTitleStyle = css`
+    font-size: 20px;
+    font-weight: bold;
+  `;
   const RequestListStyle = css`
+    width: 30vw;
     display: flex;
     flex-direction: column;
   `;
@@ -40,12 +46,12 @@ export default function RequestPage() {
     <>
       <div css={RequestPageStyle}>
         <div css={RequestListStyle}>
-          <div>나에게 온 요청</div>
+          <div css={RequestTitleStyle}>나에게 온 요청</div>
           <ProfileList datas={RequestForMe} person={person} setOpenModal={setOpenModal} />
           {RequestForMe && openModal !== null && <ProfileModal data={RequestForMe[Number(openModal)]} />}
         </div>
         <div css={RequestListStyle}>
-          <div>내가 보낸 요청</div>
+          <div css={RequestTitleStyle}>내가 보낸 요청</div>
           <ProfileList datas={RequestToMe} person={person} setOpenModal={setOpenModal} />
           {RequestToMe && openModal !== null && <ProfileModal data={RequestToMe[Number(openModal)]} />}
         </div>

--- a/client/src/Template/TeamSettingTemplate.tsx
+++ b/client/src/Template/TeamSettingTemplate.tsx
@@ -34,9 +34,9 @@ function TeamSettingTemplate() {
   return (
     <div css={TeamSettingTemPlateStyle}>
       <TeamInfoContainer>
-        <InputLabel label="팀명" placeholder={teamInfo?.teamID} />
+        {/* <InputLabel label="팀명" placeholder={teamInfo?.teamID} /> */}
         <InputLabel label="소개" placeholder={teamInfo?.info} />
-        <InputLabel label="가능시간" placeholder={teamInfo?.time} />
+        {/* <InputLabel label="가능시간" placeholder={teamInfo?.time} /> */}
         <InputLabel label="지역" placeholder={teamInfo?.location} />
       </TeamInfoContainer>
       <TeamSettingMemberContainer>


### PR DESCRIPTION
## 내용
- 요청 페이지 레이아웃 구현
- 요청 페이지 더미 데이터 연동하여 나에게 온 요청과 내가 보낸 요청 구분

## 고민
- 요청 페이지의 리스트들의 기존 css를 2열에서 1열로 줄여야 하는데 어떠한 방법을 사용해야 하는지 고민
- 요청이 팀인지 멤버인지를 구분해주는 person이라는 변수를 어떻게 처리해줄지 고민
  - 처음에 모든 데이터를 forEach로 돌 때, person이 담긴 배열을 만들어주는 방향으로 생각 중 