### PR TITLE
enhance: Preload

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -2,14 +2,19 @@ import React, { Suspense } from "react";
 import { Route } from "react-router";
 import { Routes } from "react-router-dom";
 import { Footer } from "@Core/.";
+
+import { usePreload } from "@Hook/usePreload";
 import { useSocketConnect } from "./Hook/useSocket";
 import ErrorModal from "./Component/Template/Modal/ErrorModal";
 
 const MainPage = React.lazy(() => import("@Page/MainPage/MainPage"));
 const Page = React.lazy(() => import("@Page/Page/Page"));
+const meetingImage = "Asset/meetingImage.png";
 
 export const App: React.FC = () => {
   useSocketConnect();
+  usePreload(meetingImage);
+
   return (
     <>
       <Suspense fallback={null}>

--- a/client/src/Common/reset.ts
+++ b/client/src/Common/reset.ts
@@ -1,6 +1,13 @@
 import { css } from "@emotion/react";
 
 const reset = css`
+  @font-face {
+    font-family: "BMDOHYEON";
+    src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_one@1.0/BMDOHYEON.woff") format("woff");
+    font-weight: normal;
+    font-style: normal;
+  }
+
   * {
     margin: 0;
     padding: 0;
@@ -9,6 +16,7 @@ const reset = css`
     box-sizing: border-box;
     text-decoration: none;
     color: #000000;
+    font-family: "BMDOHYEON";
   }
   *::-webkit-scrollbar {
     display: none; /* Chrome, Safari, Opera*/

--- a/client/src/Component/Atom/MainHeaderLogo/MainHeaderLogo.tsx
+++ b/client/src/Component/Atom/MainHeaderLogo/MainHeaderLogo.tsx
@@ -1,2 +1,7 @@
-const logo = "/Asset/Logo.svg";
-export const MainHeaderLogo = () => <img alt="mainLogo" src={logo} />;
+import styled from "@emotion/styled";
+
+export const MainHeaderLogo = () => <Container>CowDogTing</Container>;
+
+const Container = styled.div`
+  font-size: 32px;
+`;

--- a/client/src/Hook/usePreload.tsx
+++ b/client/src/Hook/usePreload.tsx
@@ -1,0 +1,4 @@
+export const usePreload = (src: string) => {
+  const image = new Image();
+  image.src = src;
+};

--- a/client/src/Hook/useSocket.tsx
+++ b/client/src/Hook/useSocket.tsx
@@ -1,28 +1,36 @@
 /* eslint-disable no-new */
 import { useEffect } from "react";
-import { useRecoilValue, useSetRecoilState } from "recoil";
+import { useRecoilState, useSetRecoilState } from "recoil";
+import { getFetch } from "@Common/api";
+import { JOIN_CHAT_URL, USER_URL } from "@Common/URL";
 import { chatTarget, errorState } from "../Recoil/Atom";
-import { chatsState, joinChatRoomSelector, joinChatRoomState } from "../Recoil/ChatData";
+import { chatsState, joinChatRoomState } from "../Recoil/ChatData";
 import { requestState } from "../Recoil/RequestData";
-import { userStateSelector } from "../Recoil/UserData";
+import { userState } from "../Recoil/UserData";
 import ClientSocket from "../Socket";
 import { handleReceiveRequestSocket, handleReceiveDenySocket, handleReceiveAcceptSocket, handleReceiveChatSocket } from "../Socket/chatSocket";
 import { RequestType, ChatInfoType, MessageType } from "../Common/type";
 
 export const useSocketConnect = () => {
-  const res = useRecoilValue(userStateSelector);
-  const id = res?.id;
+  const [user, setUser] = useRecoilState(userState);
+  const id = user?.id;
   const setRequest = useSetRecoilState(requestState);
-  const setJoinChat = useSetRecoilState(joinChatRoomState);
-  const joinChat = useRecoilValue(joinChatRoomSelector);
+  const [joinChat, setJoinChat] = useRecoilState(joinChatRoomState);
   const setChat = useSetRecoilState(chatsState);
   const setChatInfo = useSetRecoilState(chatTarget);
   const setErrorValue = useSetRecoilState(errorState);
 
   useEffect(() => {
+    if (id === "") getFetch({ url: USER_URL, query: "" }).then((res) => setUser(res));
+  }, [id]);
+
+  useEffect(() => {
+    if (joinChat.length === 0) getFetch({ url: JOIN_CHAT_URL, query: "" }).then((res) => setJoinChat(res));
+  }, [joinChat]);
+  useEffect(() => {
+    if (joinChat.length === 0) return;
     if (id === "") return;
     const socket = new ClientSocket(id);
-
     const handleReceiveRequestEvent = (data: RequestType) => {
       handleReceiveRequestSocket({ setRequest, data });
       if (data.from === id) return;
@@ -39,10 +47,9 @@ export const useSocketConnect = () => {
       setErrorValue({ errorStr: `${data.to}님이 요청을 승인하셨습니다.`, timeOut: 1000 });
     };
     const handleReceiveChatEvent = (data: { message: MessageType; chatRoomId: number }) => handleReceiveChatSocket({ setJoinChat, setChat, setChatInfo, data, setErrorValue });
-
     socket.addEvent({ handleReceiveRequestEvent, handleReceiveDenyEvent, handleReceiveAcceptEvent, handleReceiveChatEvent, joinChat });
     return () => socket.deleteEvent({ handleReceiveRequestEvent, handleReceiveDenyEvent, handleReceiveAcceptEvent, handleReceiveChatEvent });
-  }, [joinChat]);
+  }, [joinChat, id]);
 
   useEffect(() => {
     if (id === "") return;


### PR DESCRIPTION
ca60ac3944e11997f708f85213e0dbdb7084cf6b

make usePreload => create image tag and request img src pre-load

---

## 원인 분석 하기

![](https://velog.velcdn.com/images/0_jin/post/166179ff-dcae-4aa4-badf-6b2bbac242ea/image.png)

성능 분석을 진행한 결과이다.

FCP부터 LCP까지

Logo.svg와 meetingImage.png이다.

Largest Content는 meetingImage.png이기 때문에 Pre-loading을 진행하면 될 것 같다.
Logo.svg 또한 마찬가지이다.

---

## Pre-loading ?

```jsx
// in App.tsx
...

const img = new Image();
img.src = "~~"

...
```

위와 같이 작성하여 미리 Largest Content인 Img파일을 App에서 불러와서 시간을 단축시켜보고자 한다.
하지만, 

![](https://velog.velcdn.com/images/0_jin/post/fed063fd-4397-49f7-b0d4-306a1674651f/image.png)

계속 동일한 img를 요청할때마다 계속 네트워크 요청을 진행한다.

즉, Pre-load를 할 필요가 없게된다.

---

캐시 사용을 중지하고 보면 따단

![](https://velog.velcdn.com/images/0_jin/post/ca83a547-fa0b-459e-aca0-a9a92a5de829/image.png)


img 요청을 한번만 한다!

네트워크 요청을 보면

![](https://velog.velcdn.com/images/0_jin/post/3f8ba451-924d-4e53-b03e-70547c9089e5/image.png)

초기에 image를 전부 요청하는걸 알 수 있다.

---

## Preload 전후 비교

![](https://velog.velcdn.com/images/0_jin/post/edecbe41-d946-4f96-a027-6d88daaae5f5/image.png)

![](https://velog.velcdn.com/images/0_jin/post/1e3f0849-e552-4ff6-9308-b54a2910fa33/image.png)

FCP => 110.7ms => 110.3ms ( LCP 비교를 위한 기준 값 )
LCP => 201.3ms => 147.9ms ( 53.4 ms  약 27% 감소 )




